### PR TITLE
Do not recreate cache provider on config options change

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ function App() {
 - `version` (optional): Schema version, defaults to `1`
 - `onError` (optional): Database error handler, defaults to noop function
 
+Note: When using `useCacheProvider`, changing options doesn't create new cache provider.
 
 ## Known issues
 

--- a/src/use-cache-provider.ts
+++ b/src/use-cache-provider.ts
@@ -6,26 +6,20 @@ import createCacheProvider from './cache-provider'
 /**
  * Cache provider hook
  */
-export default function useCacheProvider<Data = any, Error = any>({
-  dbName,
-  storeName,
-  storageHandler,
-  version,
-  onError,
-}: Config): CacheProvider | undefined {
+export default function useCacheProvider<Data = any, Error = any>(props: Config): CacheProvider | undefined {
   const [ cacheProvider, setCacheProvider ] = useState<CacheProvider>()
 
   useEffect(() => {
     // False on mount or on dependency change
     let isSetup = true
 
-    createCacheProvider<Data, Error>({ dbName, storeName, storageHandler, version, onError })
+    createCacheProvider<Data, Error>(props)
       .then(cp =>
         isSetup && setCacheProvider(() => cp)
       )
 
     return () => { isSetup = false }
-  }, [dbName, storeName, storageHandler, version, onError])
+  }, [])
 
   return cacheProvider
 }


### PR DESCRIPTION
When using `useCacheProvider`, any change to options will in effect create new Cache Provider.

This PR removes this and in effect options such as `onError` or `storageHandler` don't have to be wrappend in `useMemo` or `useCallback` anymore.

For edge cases when configuration changes `createCacheProvider` should be used directly.

Fixes #7 